### PR TITLE
Fix namespace issues

### DIFF
--- a/src/com/mikebevz/xsd2php/Xsd2Php.php
+++ b/src/com/mikebevz/xsd2php/Xsd2Php.php
@@ -106,9 +106,20 @@ class Xsd2Php extends Common
      * @var array
      */
     private $importHeadNS = array();
-
+    
+    /**
+     * Map of already generated paths for a XML namespace
+     * @var array
+     */
+    private $namespaceToPath = array();
 
     /**
+     * Map of already generated PHP namespaces for an XML namespace
+     * @var array
+     */
+    private $namespaceToPhp = array();
+    
+        /**
      * XML Schema converted to XML
      *
      * @return string $xmlSource
@@ -652,6 +663,8 @@ class Xsd2Php extends Common
      * @return string
      */
     public function namespaceToPhp($xmlNS) {
+        if (!empty($this->namespaceToPhp[$xmlNS]))
+            return ($this->namespaceToPhp[$xmlNS]);
         $ns = $xmlNS;
         $ns = $this->expandNS($ns);
         if (preg_match('/urn:/',$ns)) {
@@ -700,7 +713,7 @@ class Xsd2Php extends Common
         }
 
         $ns = implode('\\', $ns);
-         
+        $this->namespaceToPhp[$xmlNS] = $ns;
         return $ns;
     }
      
@@ -711,6 +724,8 @@ class Xsd2Php extends Common
      * @return string
      */
     private function namespaceToPath($xmlNS) {
+        if (!empty($this->namespaceToPath[$xmlNS]))
+            return $this->namespaceToPath[$xmlNS];
         $ns = $xmlNS;
         $ns = $this->expandNS($ns);
 
@@ -750,6 +765,7 @@ class Xsd2Php extends Common
             $i++;
         }
         $ns = implode(DIRECTORY_SEPARATOR, $ns);
+        $this->namespaceToPath[$xmlNS] = $ns;
         return $ns;
     }
 }

--- a/src/com/mikebevz/xsd2php/Xsd2Php.php
+++ b/src/com/mikebevz/xsd2php/Xsd2Php.php
@@ -518,9 +518,13 @@ class Xsd2Php extends Common
                 $colonPos = strpos($type, ':');
                 if (empty($extendsNamespace) && $colonPos !== false)
                 {
-                    $type = substr ($type, $colonPos + 1);
-                    if (empty($phpClass->type))
-                        $phpClass->type = $type;
+                    $ns = substr($type, 0, $colonPos);
+                    if (!empty($this->shortNamespaces[$ns]) && $this->shortNamespaces[$ns] == 'http://www.w3.org/2001/XMLSchema')
+                    {
+                        $type = substr ($type, $colonPos + 1);
+                        if (empty($phpClass->type))
+                            $phpClass->type = $type;
+                    }
                 }
                 if (!in_array($type, $this->basicTypes)) {
                     $phpClass->extends = $type;

--- a/src/com/mikebevz/xsd2php/Xsd2Php.php
+++ b/src/com/mikebevz/xsd2php/Xsd2Php.php
@@ -693,6 +693,12 @@ class Xsd2Php extends Common
             foreach($elements as $key => $value) {
                 if ($value != '') {
                     $value = preg_replace('/\./', '_', $value);
+                    $hashpos = strpos($value, '#');
+                    if ($hashpos !== false)
+                    {
+                        $ns .= "\\" . substr($value, 0, $hashpos);
+                        break;
+                    }
                     $ns .= "\\" . $value;
                 }
             }
@@ -748,7 +754,14 @@ class Xsd2Php extends Common
             foreach($elements as $key => $value) {
                 if ($value != '') {
                     $value = preg_replace('/[\.|-]/', '_', $value);
+                    $hashpos = strpos($value, '#');
+                    if ($hashpos !== false)
+                    {
+                        $ns .= DIRECTORY_SEPARATOR . substr($value, 0, $hashpos);
+                        break;
+                    }
                     $ns .= DIRECTORY_SEPARATOR . $value;
+                    
                 }
             }
         }

--- a/src/com/mikebevz/xsd2php/Xsd2Php.php
+++ b/src/com/mikebevz/xsd2php/Xsd2Php.php
@@ -513,10 +513,19 @@ class Xsd2Php extends Common
             }
 
             if ($class->getElementsByTagName('extends')->length > 0) {
-                if (!in_array($class->getElementsByTagName('extends')->item(0)->getAttribute('name'), $this->basicTypes)) {
-                    $phpClass->extends = $class->getElementsByTagName('extends')->item(0)->getAttribute('name');
-                    $phpClass->type    = $class->getElementsByTagName('extends')->item(0)->getAttribute('name');
-                    $phpClass->extendsNamespace = $this->namespaceToPhp($class->getElementsByTagName('extends')->item(0)->getAttribute('namespace'));
+                $rawType = $type = $class->getElementsByTagName('extends')->item(0)->getAttribute('name');
+                $extendsNamespace = $this->namespaceToPhp($class->getElementsByTagName('extends')->item(0)->getAttribute('namespace'));
+                $colonPos = strpos($type, ':');
+                if (empty($extendsNamespace) && $colonPos !== false)
+                {
+                    $type = substr ($type, $colonPos + 1);
+                    if (empty($phpClass->type))
+                        $phpClass->type = $type;
+                }
+                if (!in_array($type, $this->basicTypes)) {
+                    $phpClass->extends = $type;
+                    $phpClass->type    = $rawType;
+                    $phpClass->extendsNamespace = $extendsNamespace;
                 }
             }
 


### PR DESCRIPTION
If an element had a basic type: 

`<xsd:element name="PayConApprovalTime" type="xsd:dateTime">`

the generated php code was buggy and did not map to a basic type

`class PayConApprovalTime extends xsd:dateTime`
